### PR TITLE
Fix http2curl import

### DIFF
--- a/printer.go
+++ b/printer.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/moul/http2curl"
+	"moul.io/http2curl"
 )
 
 // CurlPrinter implements Printer. Uses http2curl to dump requests as


### PR DESCRIPTION
# Headline
Fix http2curl import for `printer.go`

## Problem
`package github.com/moul/http2curl: code in directory $GOPATH/src/github.com/moul/http2curl expects import "moul.io/http2curl"`

## Solution
User the package `moul.io/http2curl` instead `github.com/moul/http2curl`